### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Version of Arduino's LiquidCrystal with an internal queue, suitable fo
 category=Display
 url=http://www.arduino.cc/en/Reference/LiquidCrystal
 architectures=*
+depends=Buffered Streams

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AsyncLiquidCrystal
-version=1.0.0
+version=1.0.1
 author=Paulo Costa, Arduino, Adafruit
 maintainer=Arduino <info@arduino.cc>
 sentence=Allows communication with alphanumerical liquid crystal displays (LCDs), in a non-blocking way.


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format